### PR TITLE
fix(api): added linebreaks to post descriptions

### DIFF
--- a/src/routes/api/utils.js
+++ b/src/routes/api/utils.js
@@ -15,7 +15,9 @@ export function getDescription (obj = {}, param = { truncated: false}) {
     const description = keys.map(key => {
       return obj.description[key]._text
     })
-      .join("<br>");
+      .join("")
+      .replace(/\n/g, "<br>");
+
     const truncated = truncateDesc(description);  
     
     return param.truncated ?


### PR DESCRIPTION
- linebreaks were missing from post descriptions
- every `\n` character is now replaced by `<br>` in descriptions