### PR TITLE
fix: infinite scroll behaviour

### DIFF
--- a/src/lib/components/Post/Post.svelte
+++ b/src/lib/components/Post/Post.svelte
@@ -72,6 +72,7 @@ import { onMount } from "svelte";
     align-items: center;
     gap: 1em;
     border-bottom: 1px solid #ccc;
+    min-height: 30vh;
   }
 
   article:first-child {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -31,19 +31,17 @@
   
   loadedPostIds.set(ids);
   
-  console.log("feed is at beginning ")
-  console.log($feed.length)
-  
   let limit = INITIAL_POSTS;
   
   $: limitReached = () => {
-    return MAX_POSTS <= $feed.length;
+    return (MAX_POSTS <= limit);
   };
-  
+
   //intersection obs
-  
+
+  let observer;
   onMount(() => {
-    if (browser && document.querySelector('article')) {
+    if (browser && document.querySelector('footer')) {
       const handleIntersect = (entries, observer) => {
         entries.forEach((entry) => {
           if (limitReached()) {
@@ -54,10 +52,9 @@
         });
       };
       const options = { threshold: 0.25, rootMargin: '-100% 0% 100%' };
-      const observer = new IntersectionObserver(handleIntersect, options);
-      observer.observe(document.querySelector('article:last-of-type'));
+      observer = new IntersectionObserver(handleIntersect, options);
+      observer.observe(document.querySelector('footer'));
     }
-    
     //update savedPostsstore
     updateStore()
   });
@@ -70,12 +67,12 @@
       if (newLimit <= $feed.length) {
         // load more images from store
         console.log('loaded posts from store')
+
         limit = newLimit;
       } else {
         const newPosts = await loadPosts(ADDITONAL_POSTS_TO_FETCH);
         console.log('fetched new posts')
         feed.set([...$feed, ...newPosts.posts]);
-        console.log($feed.length)
         
         limit = newLimit;
       }
@@ -97,6 +94,7 @@
       feed.set(newPosts.posts);
       loadedPostIds.set(newPosts.ids);
       limit = INITIAL_POSTS;
+      observer.observe(document.querySelector('footer'));
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
- limitReached() returned incorrect value
- observer needs to be restarted after requesting new posts
- added minimum height to posts so observer won't fire twice on load
- observer is observing the `footer` instead of the last post