### PR TITLE
feat: clicking on image opens it on new tab

### DIFF
--- a/src/lib/components/Image/Image.svelte
+++ b/src/lib/components/Image/Image.svelte
@@ -1,6 +1,7 @@
 <script>
   export let src
   export let alt
+  export let link
 
   import { onMount } from 'svelte'
 
@@ -17,7 +18,13 @@
 {#if !loaded} 
   <div class="placeholder"></div>
 {/if}
-<img {src} {alt} class:loaded bind:this={thisImage} loading="lazy"/>
+{#if link}
+<a href="{link}" target="_blank">
+  <img {src} {alt} class:loaded bind:this={thisImage} loading="lazy"/>
+</a>
+{:else}
+  <img {src} {alt} class:loaded bind:this={thisImage} loading="lazy"/>
+{/if}
 
 
 <style>

--- a/src/routes/api/posts/[id].json.js
+++ b/src/routes/api/posts/[id].json.js
@@ -1,6 +1,6 @@
 import { xml2js } from 'xml-js';
 
-import { getPictureUrl, getDescription, getRelated, getCookie, isSaved } from '../utils';
+import { getPictureUrl, getDescription, getRelated, getCookie, isSaved, getLargePictureUrl } from '../utils';
 
 export const get = async ({params, request}) => {
   const { id } = await params;
@@ -18,6 +18,7 @@ export const get = async ({params, request}) => {
   // console.log(xml.dkalista.DKA.original_document)
 
   const img = getPictureUrl(await xml.dkalista.DKA.identifier.Filename._text, await xml.dkalista.DKA.identifier.URLOfDoc._text);
+  const largeImg = getLargePictureUrl(img);
   const title = await xml.dkalista.DKA.DKAtitle.MainTitle._text; 
   const description = getDescription(await xml.dkalista.DKA);
   const related = getRelated(await xml.dkalista.DKA.relation);
@@ -28,14 +29,15 @@ export const get = async ({params, request}) => {
 
   const post = {
     id,
-    saved,
+    img,
+    largeImg,
     title,
     description,
-    img,
     related,
     originalUrl,
     src,
-    srcUrl
+    srcUrl,
+    saved
   };
 
   // console.log(post)

--- a/src/routes/api/utils.js
+++ b/src/routes/api/utils.js
@@ -23,6 +23,10 @@ export function getPictureUrl (filename = "", url = "") {
   return `${url}/${filename}`
 };
 
+export function getLargePictureUrl (path = "") {
+  return path.replace(/\.jpg$/, '_nagykep.jpg');
+};
+
 export function getDescription (obj = {}, param = { truncated: false}) {
   if (obj.description) {
     const keys = Object.keys(obj.description);

--- a/src/routes/posts/[id].svelte
+++ b/src/routes/posts/[id].svelte
@@ -20,7 +20,7 @@
   import { onMount } from 'svelte';
   import { savePost, deleteSavedPost, saved, updateStore, sharePost } from '../posts/utils';  
   import { writable } from "svelte/store";
-  import ImageLoader from '$lib/components/Image/ImageLoader.svelte';
+  import Image from '$lib/components/Image/Image.svelte';
   
   export let post;
 
@@ -55,7 +55,7 @@
     <a href="/" title="Vissza a főoldalra"><i class="ri-arrow-left-s-line"></i></a>
   </header>
 
-  <ImageLoader src={post.img} alt={`${post.title} kép`}/>
+  <Image src={post.img} alt={`${post.title}`} link={post.largeImg}/>
   <p>{@html post.description}</p>
 
   <span class="divider" aria-hidden="true"></span>
@@ -78,11 +78,6 @@
     <button on:click="{()=> sharePost(shareData)}">
       <i class="ri-share-line"></i>
       <span>Megosztás</span>
-    </button>
-    
-    <button >
-      <i class="ri-download-fill"></i>
-      <span>Letöltés</span>
     </button>
     
   </section>


### PR DESCRIPTION
- The endpoint for individual posts now returns the URL of the larger versions of images in its response. The URL is passed down to the `Image` component, which renders an anchor tag around the normal image conditionally.
- Download button has become obsolete and has been removed