### PR TITLE
fix: saved posts were not rendered

### DIFF
--- a/src/routes/saved/index.svelte
+++ b/src/routes/saved/index.svelte
@@ -38,11 +38,13 @@
     }
   }
 
-  if ($feed.length === 0 && (!$savedPosts || $savedPosts.length === 0)) {
+  $: $savedPosts, checkForSavedPosts();
+
+  function checkForSavedPosts () {
+    if ($feed.length === 0 && (!$savedPosts || $savedPosts.length === 0)) {
     noSavedItems = true;
+   }
   }
-
-
   // export let ids;
 
   feed.set(posts);


### PR DESCRIPTION
* condition to render no saved posts message was set to true

* condition is now checked whenever savedPosts store is updated