### PR TITLE
feat(api): add topics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sveltekit-xmltest",
       "version": "0.0.1",
       "dependencies": {
+        "cheerio": "^1.0.0-rc.10",
         "remixicon": "^2.5.0",
         "xml-js": "^1.6.11"
       },
@@ -152,6 +153,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -171,6 +177,41 @@
         "node": "*"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "dependencies": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "dependencies": {
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -187,6 +228,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/debug": {
@@ -213,6 +280,65 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/errno": {
@@ -566,6 +692,24 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -791,6 +935,17 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -807,6 +962,19 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dependencies": {
+        "parse5": "^6.0.1"
       }
     },
     "node_modules/path-is-absolute": {
@@ -1139,8 +1307,7 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/vite": {
       "version": "2.7.13",
@@ -1308,6 +1475,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1324,6 +1496,32 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
+    "cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "requires": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "cheerio-select": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "requires": {
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1339,6 +1537,23 @@
         "is-what": "^3.14.1"
       }
     },
+    "css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1353,6 +1568,44 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
+    },
+    "dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "errno": {
       "version": "0.1.8",
@@ -1580,6 +1833,17 @@
         "function-bind": "^1.1.1"
       }
     },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1751,6 +2015,14 @@
         }
       }
     },
+    "nth-check": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1765,6 +2037,19 @@
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
       "dev": true
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "requires": {
+        "parse5": "^6.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1981,8 +2266,7 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "vite": {
       "version": "2.7.13",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "type": "module",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.10",
     "remixicon": "^2.5.0",
     "xml-js": "^1.6.11"
   }

--- a/src/lib/components/Common/Seo/Seo.svelte
+++ b/src/lib/components/Common/Seo/Seo.svelte
@@ -1,5 +1,6 @@
 <script>
-  import { TITLE_SUFFIX } from '$lib/config/general'
+  import { TITLE_SUFFIX } from '$lib/config/general';
+  import logo from '$lib/assets/dkalogo.jpg';
 
   export let title;
   export let description;
@@ -25,7 +26,7 @@
   <meta name="twitter:description" content={description} />
   <meta name="twitter:url" content={url} />
   {#if image}
-  <meta name="twitter:image" content={image.url} />
+  <meta name="twitter:image" content={image.url? image.url : logo} />
     <meta name="twitter:image:alt" content={image.alt} />
   {/if}
 
@@ -34,6 +35,10 @@
   <meta property="og:type" content="{contentType}" />
   <meta property="og:title"  content="{metaTitle}" />
   <meta property="og:description" content="{description}" />
-  <meta property="og:image" itemprop="image" content="{image.url}" />
+  <meta property="og:image" itemprop="image" content="{image.url? image.url : logo}" />
+
+  <!-- colour -->
+  <meta name="theme-color" content="#cccccc" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#2a2a2a" media="(prefers-color-scheme: dark)">
   
 </svelte:head>

--- a/src/lib/components/InfiniteScroller/InfiniteScroller.svelte
+++ b/src/lib/components/InfiniteScroller/InfiniteScroller.svelte
@@ -1,0 +1,53 @@
+<script context="module">
+  import { writable } from "svelte/store";
+
+  export const observe = writable(true);
+
+</script>
+
+<script>
+  import { onMount } from "svelte/internal";
+  import {browser} from "$app/env";
+
+  export let elementToObserve;
+  export let limitReached = false;
+  // export let limit;
+  // export let limitStep = 6;
+  // export let feedLength;
+  // export let additionalPostsToFetch;
+  export let showMorePosts;
+  
+  
+  let observer;
+  onMount(() => {
+    
+    // updateStore() update in index.svelte!
+    
+    if (browser && document.querySelector(elementToObserve)) {
+      const handleIntersect = (entries, observer) => {
+        entries.forEach((entry) => {
+          if (limitReached) {
+            console.log("Limit reached");
+            observer.unobserve(entry.target);
+            observe.set(false);
+          }
+          showMorePosts();
+        });
+      };
+      const options = { threshold: 0.25, rootMargin: '-100% 0% 100%' };
+      observer = new IntersectionObserver(handleIntersect, options);
+      observer.observe(document.querySelector(elementToObserve));
+    }
+  });
+
+  $: $observe, restart();
+
+  function restart () {
+    if (observer && $observe) {
+      observer.observe(document.querySelector(elementToObserve));
+    }
+  }
+
+</script>
+
+<slot></slot>

--- a/src/lib/components/Post/Post.less
+++ b/src/lib/components/Post/Post.less
@@ -44,6 +44,21 @@
     align-items: center;
   }
 
+  section.topics {
+    width: clamp(200px, 100%, 600px);
+    padding: 0 1em;
+    display: flex; 
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 0.25em 0.5em;
+    
+    a {
+      .default-font();
+      text-decoration: underline;
+      color: var(--font-color-link)
+    }
+  }
+
   section.button-wrapper {
     width: clamp(200px, 100%, 600px);
     display: flex;
@@ -85,6 +100,10 @@
       h2 {
         margin-bottom: 0;
       }
+    }
+
+    section.topics {
+      gap: 0.5em .75em;
     }
 
   }

--- a/src/lib/components/Post/Post.svelte
+++ b/src/lib/components/Post/Post.svelte
@@ -3,7 +3,7 @@
   import { savePost, unSavePost, isSaved, sharePost } from './post.utils';
   import { onMount } from "svelte";
   import { page } from '$app/stores'
-  import ImageLoader from "../Image/ImageLoader.svelte";
+  import ImageLoader from "$lib/components/Image/ImageLoader.svelte";
   
   export let post = {};
 
@@ -26,11 +26,22 @@
   <h2>{post.title}</h2>
   <ImageLoader src="{post.img}" alt="{post.title}" href={{url: postLink}} />
 
+  {#if post.topics}
+  <section class="topics">
+    {#each post.topics as topic}
+      <a href={"/topic/" + topic}>#{topic}</a>
+    {/each}
+  </section>
+  {/if}
+
   {#if post.description}
+  <section class="description">
     <p>
       {@html post.description}
     </p>
+  </section>  
   {/if}
+
 
   <section class="button-wrapper">
     {#if $saved}

--- a/src/lib/config/topics.js
+++ b/src/lib/config/topics.js
@@ -1,0 +1,10 @@
+const META_DESCRIPTION = "A Digitális Képarchívum ehhez kapcsolódó képei: ";
+const TYPE = "website"
+
+export const TOPIC_FEED_SEO = {
+  description: META_DESCRIPTION,
+  contentType: TYPE,
+  image: {
+    alt: "DKA logo"
+  }
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -103,6 +103,35 @@ function getOriginalFieldValue (obj = {}, key = '') {
   }
 }
 
+export function getKeywords (obj = {}) {
+  let keywords = null;
+  const subjects = obj.subject;
+
+  if (subjects && subjects.length) {
+    keywords = subjects.map(subject => subject.Keyword._text);
+  } else if (subjects && !subjects.length) {
+    keywords = subjects.Keyword._text;
+  }
+
+  return keywords;
+}
+
+export function encodeURIforDKA (str = "") {
+  const encoded = str
+    .replace(/á/g, "%E1")
+    .replace(/é/g, "%e9")
+    .replace(/í/g, "%ed")
+    .replace(/ó/g, "%f3")
+    .replace(/ö/g, "%f6")
+    .replace(/ő/g, "%F5")
+    .replace(/ú/g, "%fa")
+    .replace(/ü/g, "%fc")
+    .replace(/ű/g, "%fb")
+    .replace(/\s/g, "_");
+  
+  return encoded;
+}
+
 const ORIGINAL_FIELDS = {
   OriginalTitle: "Cím",
   OriginalAttendance: "Megjelenés",
@@ -157,8 +186,9 @@ export function truncateDesc (str="") {
 	return str.split("").slice(0, cutoff).join("") + "...";
 };
 
-function getIdFromUrl (str = "") {
-  const id = str.replace(/.*(\/|id=)(\d+)$/, "$2");
+export function getIdFromUrl (str = "") {
+  const url = str.replace(/\s/g, ""); //remove whitespace
+  const id = url.replace(/.*(\/|id=)(\d+)$/, "$2");
   return id;
 };
 

--- a/src/routes/api/posts.js
+++ b/src/routes/api/posts.js
@@ -1,0 +1,35 @@
+import { xml2js } from 'xml-js';
+import { getPictureUrl, getDescription, getKeywords } from '$lib/utils';
+
+export const post = async ({ request }) => {
+  
+  const body = JSON.parse(await request.text());
+  const ids = await body.ids.ids;
+  
+  const posts = await ids.reduce(async (prevPromise, id) => {
+    let posts = await prevPromise;
+    const res = await fetch(`https://dka.oszk.hu/export/xml_/${id}.xml`);
+    if (res.ok) {
+      const text = await res.text();
+      const js = xml2js(text, {compact: true});
+      const post = {
+        img: getPictureUrl(js.dkalista.DKA.identifier.Filename._text, js.dkalista.DKA.identifier.URLOfDoc._text),
+        title: js.dkalista.DKA.DKAtitle.MainTitle._text,
+        description: getDescription(js.dkalista.DKA, { truncated: true}),
+        topics: getKeywords(js.dkalista.DKA),
+        id: id
+      }
+      posts.push(post);
+    }
+    return posts;
+  }, []);
+  
+  return {
+    status: 200,
+    body: {
+      posts
+    }
+  };
+  
+
+}

--- a/src/routes/api/posts.json.js
+++ b/src/routes/api/posts.json.js
@@ -1,5 +1,5 @@
 import { xml2js } from 'xml-js';
-import { getPictureUrl, getDescription, getIds, getCookie } from '$lib/utils';
+import { getPictureUrl, getDescription, getIds, getCookie, getKeywords } from '$lib/utils';
 
 export const post = async ({ request }) => {
   
@@ -29,6 +29,7 @@ export const post = async ({ request }) => {
         img: getPictureUrl(js.dkalista.DKA.identifier.Filename._text, js.dkalista.DKA.identifier.URLOfDoc._text),
         title: js.dkalista.DKA.DKAtitle.MainTitle._text,
         description: getDescription(js.dkalista.DKA, { truncated: true}),
+        topics: getKeywords(js.dkalista.DKA),
         id: id
       }
       posts.push(post);

--- a/src/routes/api/posts.json.js
+++ b/src/routes/api/posts.json.js
@@ -19,6 +19,8 @@ export const post = async ({ request }) => {
     idString = previousIds ? JSON.stringify([ ...previousIds, ...ids]) : JSON.stringify(ids);
   } 
   
+
+  // to do: fetch'/api/posts' instead
   const posts = await ids.reduce(async (prevPromise, id) => {
     let posts = await prevPromise;
     const res = await fetch(`https://dka.oszk.hu/export/xml_/${id}.xml`);

--- a/src/routes/api/posts/[id].json.js
+++ b/src/routes/api/posts/[id].json.js
@@ -7,7 +7,8 @@ import {
   getCookie,
   isSaved,
   getLargePictureUrl,
-  getOriginals } from '$lib/utils';
+  getOriginals,
+  getKeywords } from '$lib/utils';
 
 export const get = async ({params, request}) => {
   const { id } = await params;
@@ -20,6 +21,7 @@ export const get = async ({params, request}) => {
   const text = await res.text();
   const xml = xml2js(text, {compact: true});
 
+  
   const img = getPictureUrl(await xml.dkalista.DKA.identifier.Filename._text, await xml.dkalista.DKA.identifier.URLOfDoc._text);
   const largeImg = getLargePictureUrl(img);
   const title = await xml.dkalista.DKA.DKAtitle.MainTitle._text; 
@@ -29,6 +31,7 @@ export const get = async ({params, request}) => {
   const src = await xml.dkalista.DKA.source?.NameOfSource?._text || null;
   const srcUrl = await xml.dkalista.DKA.source?.URLOfSource?._text || null;
   const originals = getOriginals(await xml.dkalista.DKA.original_document || null)
+  const topics = getKeywords(xml.dkalista.DKA);
 
   const post = {
     id,
@@ -41,7 +44,8 @@ export const get = async ({params, request}) => {
     src,
     srcUrl,
     saved,
-    originals
+    originals,
+    topics
   };
 
   return {

--- a/src/routes/api/saved-posts.json.js
+++ b/src/routes/api/saved-posts.json.js
@@ -30,6 +30,8 @@ export const post = async ({request}) => {
     };
   }
 
+  
+  // to do: fetch'/api/posts' instead
   const posts = await ids.reduce(async (prevPromise, id) => {
     let posts = await prevPromise;
     const res = await fetch(`https://dka.oszk.hu/export/xml_/${id}.xml`);

--- a/src/routes/api/saved-posts.json.js
+++ b/src/routes/api/saved-posts.json.js
@@ -1,5 +1,5 @@
 import { xml2js } from 'xml-js';
-import { getPictureUrl, getDescription, getCookie } from '$lib/utils';
+import { getPictureUrl, getDescription, getCookie, getKeywords } from '$lib/utils';
 
 export const post = async ({request}) => {
 
@@ -40,6 +40,7 @@ export const post = async ({request}) => {
         img: getPictureUrl(js.dkalista.DKA.identifier.Filename._text, js.dkalista.DKA.identifier.URLOfDoc._text),
         title: js.dkalista.DKA.DKAtitle.MainTitle._text,
         description: getDescription(js.dkalista.DKA, { truncated: true}),
+        topics: getKeywords(js.dkalista.DKA),
         id: id
       }
       posts.push(post);

--- a/src/routes/api/topic/[topic].json.js
+++ b/src/routes/api/topic/[topic].json.js
@@ -1,0 +1,52 @@
+import * as cheerio from 'cheerio';
+import { xml2js } from 'xml-js';
+import { getIdFromUrl, getPictureUrl, getDescription, encodeURIforDKA, getKeywords } from '$lib/utils';
+
+export const get = async ({ request, params }) => {
+  const { topic } = await params;
+  // const query = await topic.normalize("NFD").replace(/\p{Diacritic}/gu, "").replace(/\s/g, "_");
+  const query = await topic;
+  const url = `https://dka.oszk.hu/kereses/keres_cedulaelem.php?kulcsszo=${encodeURIforDKA(query)}`;
+  const markup = await (await fetch(url)).text();
+
+  const $ = cheerio.load(markup);
+  const rows = $('table:nth-of-type(3) tbody').children();
+
+  const ids = [];
+  rows.each((i, el) => {
+    const href = $(el).find('td a:nth-of-type(3)').text();
+    const id = getIdFromUrl(href);  
+    ids.push(id);
+  });
+
+  // console.log(ids)
+
+    
+  const posts = await ids.reduce(async (prevPromise, id) => {
+    let posts = await prevPromise;
+    const res = await fetch(`https://dka.oszk.hu/export/xml_/${id}.xml`);
+    if (res.ok) {
+      const text = await res.text();
+      const js = xml2js(text, {compact: true});
+      const post = {
+        img: getPictureUrl(js.dkalista.DKA.identifier.Filename._text, js.dkalista.DKA.identifier.URLOfDoc._text),
+        title: js.dkalista.DKA.DKAtitle.MainTitle._text,
+        description: getDescription(js.dkalista.DKA, { truncated: true}),
+        topics: getKeywords(js.dkalista.DKA),
+        id: id
+      }
+      posts.push(post);
+    }
+    return posts;
+  }, []);
+
+  return {
+    status: 200,
+    body: {
+      posts,
+      ids
+    }
+  }
+
+
+}

--- a/src/routes/api/topic/[topic].json.js
+++ b/src/routes/api/topic/[topic].json.js
@@ -1,10 +1,8 @@
 import * as cheerio from 'cheerio';
-import { xml2js } from 'xml-js';
-import { getIdFromUrl, getPictureUrl, getDescription, encodeURIforDKA, getKeywords } from '$lib/utils';
+import { getIdFromUrl, encodeURIforDKA } from '$lib/utils';
 
 export const get = async ({ request, params }) => {
   const { topic } = await params;
-  // const query = await topic.normalize("NFD").replace(/\p{Diacritic}/gu, "").replace(/\s/g, "_");
   const query = await topic;
   const url = `https://dka.oszk.hu/kereses/keres_cedulaelem.php?kulcsszo=${encodeURIforDKA(query)}`;
   const markup = await (await fetch(url)).text();
@@ -19,31 +17,10 @@ export const get = async ({ request, params }) => {
     ids.push(id);
   });
 
-  // console.log(ids)
-
-    
-  const posts = await ids.reduce(async (prevPromise, id) => {
-    let posts = await prevPromise;
-    const res = await fetch(`https://dka.oszk.hu/export/xml_/${id}.xml`);
-    if (res.ok) {
-      const text = await res.text();
-      const js = xml2js(text, {compact: true});
-      const post = {
-        img: getPictureUrl(js.dkalista.DKA.identifier.Filename._text, js.dkalista.DKA.identifier.URLOfDoc._text),
-        title: js.dkalista.DKA.DKAtitle.MainTitle._text,
-        description: getDescription(js.dkalista.DKA, { truncated: true}),
-        topics: getKeywords(js.dkalista.DKA),
-        id: id
-      }
-      posts.push(post);
-    }
-    return posts;
-  }, []);
 
   return {
     status: 200,
     body: {
-      posts,
       ids
     }
   }

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -23,7 +23,6 @@
   import { feed, loadedPostIds } from '$lib/components/stores/posts';
   import { updateStore } from '$lib/components/stores/saved-posts'
   import { page } from '$app/stores';
-  import logo from '$lib/assets/dkalogo.jpg';
   import Post from '$lib/components/Post/Post.svelte';
   import Seo from '$lib/components/Common/Seo/Seo.svelte';
 
@@ -32,7 +31,6 @@
 
   const {title, description, contentType, image } = HOMEFEED_SEO;
   const url = $page.url.href;
-  image.url = logo;
 
   feed.set(posts);
   

--- a/src/routes/posts/Post.less
+++ b/src/routes/posts/Post.less
@@ -25,14 +25,29 @@ main {
 section {
   display: flex;
   justify-content: space-between;
-  border-bottom: 1px solid var(--ui-tertiary);
+  &:not(:nth-of-type(1)) {
+    border-bottom: 1px solid var(--ui-tertiary);
+  }
 
   h5 {
     .subtitle-font();
     color: var(--font-color-default);
   }
   
- 
+}
+
+section.topics {
+  padding: 0 1em;
+  display: flex; 
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 0.25em 0.5em;
+  
+  a {
+    .default-font();
+    text-decoration: underline;
+    color: var(--font-color-link)
+  }
 }
 
 section.button-wrapper {
@@ -158,4 +173,9 @@ div.link-wrapper > a {
   main > * {
     padding: 2em 0;
   }
+
+  section.topics {
+    gap: 0.5em .75em;
+  }
+
 }

--- a/src/routes/posts/[id].svelte
+++ b/src/routes/posts/[id].svelte
@@ -67,7 +67,14 @@
   {#if post.description}
     <p>{@html post.description}</p>
   {/if}
-
+  
+  {#if post.topics}
+  <section class="topics">
+    {#each post.topics as topic}
+      <a href={"/topic/" + topic}>#{topic}</a>
+    {/each}
+  </section>
+  {/if}
   
   <section class="button-wrapper">
     

--- a/src/routes/saved/index.svelte
+++ b/src/routes/saved/index.svelte
@@ -24,14 +24,11 @@
   import { savedPosts } from '$lib/components/stores/saved-posts'
   import { updateStore, feed } from '$lib/components/stores/saved-posts'
   import Message from '$lib/components/Message/Message.svelte'
-  import logo from '$lib/assets/dkalogo.jpg';
   import Post from '$lib/components/Post/Post.svelte';
   import Seo from '$lib/components/Common/Seo/Seo.svelte';
 
   const {title, description, contentType, image } = SAVEDFEED_SEO;
   const url = $page.url.href;
-  image.url = logo;
-
 
   export let posts;
 

--- a/src/routes/saved/index.svelte
+++ b/src/routes/saved/index.svelte
@@ -19,10 +19,11 @@
 <script>
   import { LIMIT_STEP, ADDITONAL_POSTS_TO_FETCH, INITIAL_POSTS, SAVEDFEED_SEO } from '$lib/config/saved-posts';
   import { onMount } from 'svelte';
-  import { browser } from '$app/env';
   import { page } from '$app/stores';
   import { savedPosts } from '$lib/components/stores/saved-posts'
   import { updateStore, feed } from '$lib/components/stores/saved-posts'
+
+  import InfiniteScroller from '$lib/components/InfiniteScroller/InfiniteScroller.svelte';
   import Message from '$lib/components/Message/Message.svelte'
   import Post from '$lib/components/Post/Post.svelte';
   import Seo from '$lib/components/Common/Seo/Seo.svelte';
@@ -64,28 +65,11 @@
     }
   };
   
-  //intersection obs
   onMount(() => {
-    updateStore();
-
-    if (browser && $savedPosts && document.querySelector('footer')) { 
-      const handleIntersect = (entries, observer) => {
-        entries.forEach((entry) => {
-          if (limitReached()) {
-            observer.unobserve(entry.target);
-          }
-          showMorePosts();
-        });
-      };
-      const options = { threshold: 0.25, rootMargin: '-100% 0% 100%' };
-      const observer = new IntersectionObserver(handleIntersect, options);
-      observer.observe(document.querySelector('footer'));
-    }
-    
     //update savedPostsstore
+    updateStore();
   });
 
-  $: showMorePosts;
   async function showMorePosts() {
     try {
       const newLimit = limit + LIMIT_STEP;
@@ -135,9 +119,18 @@
   {#if noSavedItems}
    <Message message={noSavedItemsMessage}/>   
   {:else}
+
+  <InfiniteScroller
+    elementToObserve={'footer'}
+    limitReached={limitReached()}
+    showMorePosts={()=>showMorePosts()}
+  >
+
     {#each $feed?.slice(0, limit) as post}
       <Post post={post} />
     {/each}
+  
+  </InfiniteScroller>
   {/if}
 
 </main>

--- a/src/routes/topic/[topic].svelte
+++ b/src/routes/topic/[topic].svelte
@@ -17,15 +17,40 @@
 
 </script>
 <script>
+  import {TOPIC_FEED_SEO} from '$lib/config/topics';
+  import { page } from '$app/stores';
+
   import Post from '$lib/components/Post/Post.svelte';
+  import Seo from '$lib/components/Common/Seo/Seo.svelte';
 
   export let posts;
   export let topic;
+
+  TOPIC_FEED_SEO.description = TOPIC_FEED_SEO.description + topic;
+  const { description, contentType, image } = TOPIC_FEED_SEO;
+  const url = $page.url.href;
+  
+
 </script>
 
+<style>
+  h1 {
+    margin-top: 2.5em;
+  }
+</style>
+
 <main class="container">
-  <h1>{topic}</h1>
+  <h1>#{topic}</h1>
   {#each posts as post}
     <Post post={post} />
   {/each}
 </main>
+
+
+<Seo 
+  title={topic}
+  {description}
+  {url}
+  {contentType}
+  {image}
+/>

--- a/src/routes/topic/[topic].svelte
+++ b/src/routes/topic/[topic].svelte
@@ -1,12 +1,20 @@
 <script context="module">
 
- export async function load ({fetch, params}) {
+ export async function load ({fetch, params, url}) {
   const { topic } = await params;
+  const page = await url.searchParams.get("page");
+  
   const res = await fetch(`/api/topic/${topic}.json`);
+  const ids = await res.json();
 
-  const {posts, ids} = await res.json();
+
+  const requestBody = JSON.stringify({ids});
+  const postsRes = await fetch(`/api/posts`, {method: 'POST', body: requestBody});
+
+  const posts = await postsRes.json();
 
   return {
+    status: res.status,
     props: {
       posts,
       ids,
@@ -25,6 +33,9 @@
 
   export let posts;
   export let topic;
+  export let ids;
+
+  console.log(ids)
 
   TOPIC_FEED_SEO.description = TOPIC_FEED_SEO.description + topic;
   const { description, contentType, image } = TOPIC_FEED_SEO;
@@ -41,7 +52,7 @@
 
 <main class="container">
   <h1>#{topic}</h1>
-  {#each posts as post}
+  {#each posts.posts as post}
     <Post post={post} />
   {/each}
 </main>

--- a/src/routes/topic/[topic].svelte
+++ b/src/routes/topic/[topic].svelte
@@ -1,0 +1,31 @@
+<script context="module">
+
+ export async function load ({fetch, params}) {
+  const { topic } = await params;
+  const res = await fetch(`/api/topic/${topic}.json`);
+
+  const {posts, ids} = await res.json();
+
+  return {
+    props: {
+      posts,
+      ids,
+      topic
+    }
+  }
+}
+
+</script>
+<script>
+  import Post from '$lib/components/Post/Post.svelte';
+
+  export let posts;
+  export let topic;
+</script>
+
+<main class="container">
+  <h1>{topic}</h1>
+  {#each posts as post}
+    <Post post={post} />
+  {/each}
+</main>


### PR DESCRIPTION
### Fetch topics & documents related to topics
* add `cheerio` to fetch ids of documents related to topics
* add `getKeyword` utility function to get topic keywords from documents and render them
* clicking on rendered topics will lead to the `/topic/[slug]` route
 **To do:** 
* add ifinite scroll and pagination

### Remove duplicate code
* add `InfinteScroller.svelte` to endpoints with post feed to remove some duplicate code

**To do:**
* remove duplicate code from api-endpoints