### PR TITLE
fix: incorrect back navigation on posts

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,3 +1,5 @@
+import { browser } from "$app/env";
+
 export function getRelated (relation) {
   let relatedPosts = [];
   
@@ -209,4 +211,21 @@ export const isSaved = (savedIds=[], id="") => {
     return savedIds.includes(id);
   }
   return false
+}
+
+export function updateHistory(pathname) {
+  if (browser && isPathToStore(pathname)) {
+    const previousPath = JSON.stringify(pathname);
+    sessionStorage.setItem('prevPath', previousPath);      
+  }
+}
+
+export function getPreviousFeedPath () {
+  const previousPath = JSON.parse(sessionStorage.getItem('prevPath'));
+  return previousPath;
+}
+
+const isPathToStore = (pathname) => {
+  const regex = /^\/$|topic|saved/;
+  return regex.test(pathname);
 }

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,16 +1,20 @@
 <script>
   import { theme } from '$lib/components/stores/theme';
-  import { navigating } from '$app/stores';
-  import {fade} from 'svelte/transition';
+  import { navigating, page } from '$app/stores';
   import Menu from '$lib/components/Menu/Menu.svelte';
   import Footer from '$lib/components/Footer/Footer.svelte';
   import Alert from '$lib/components/Common/Alert/Alert.svelte';
   import Loading from '$lib/components/Loading/Loading.svelte';
+  import {updateHistory} from '$lib/utils'
+
+  $: $page, updateHistory($page.url.pathname);
+
 </script>
 
 <style>
   @import '$lib/styles/global.css';
 </style>
+
 <div id="app-wrapper" class="{$theme}">
   <Menu />
   

--- a/src/routes/posts/Post.less
+++ b/src/routes/posts/Post.less
@@ -175,12 +175,12 @@ header {
     flex-grow: 1;
   }
 
-  span {
+  a {
     margin-right: 0.25em;
     display: flex;
     align-items: center;
     justify-content: center;
-    cursor: pointer;
+    text-decoration: none;
  
     i {
       .default-icon();

--- a/src/routes/posts/[id].svelte
+++ b/src/routes/posts/[id].svelte
@@ -21,13 +21,18 @@
   import { savePost, deleteSavedPost, saved, updateStore, sharePost, } from '../posts/utils';  
   import { writable } from "svelte/store";
   import Image from '$lib/components/Image/Image.svelte';
-  import { page, navigating } from '$app/stores';
+  import { page } from '$app/stores';
   import Seo from '$lib/components/Common/Seo/Seo.svelte';
-  import { truncateDesc } from '$lib/utils';
-
-  onMount(()=> {updateStore(); console.log(window.history)})
+  import { truncateDesc, getPreviousFeedPath } from '$lib/utils';
 
   export let post;
+  let prevPath;
+
+  onMount(()=> {
+    updateStore();
+    prevPath = getPreviousFeedPath() || "/";
+  });
+
 
   const shareData = {
     title: `${post.title}`,
@@ -46,14 +51,6 @@
     deleteSavedPost(id);
     isSaved.set(false);
   };
-
-  function goBack () {
-    if (window.history.length > 1) {
-      window.history.back()
-    } else {
-      window.location.href = '/';
-    }
-  }
   
 </script>
 
@@ -65,19 +62,21 @@
     
   <header>
     <h1>{post.title}</h1>
-    <span role="navigation" title="Vissza" on:click="{goBack}">
+    <a role="navigation" title="Vissza" href="{prevPath}">
       <i class="ri-arrow-left-line"></i>
-    </span>
+    </a>
   </header>
 
   <Image src={post.img} alt={`${post.title}`} href={{ url: post.largeImg, target: '_blank'}}/>
 
+  <!-- description -->
   {#if post.description}
   <section class="description">
     <p>{@html post.description}</p>
   </section>
   {/if}
   
+  <!-- topics -->
   {#if post.topics}
   <section class="topics">
     {#each post.topics as topic}


### PR DESCRIPTION
Instead of relying on browser history, the `href` of the back button is the last feed's path or `"/"` by default.

When a new feed is added, it's path should be added to the regex in `getPreviousFeedPath` utility function.